### PR TITLE
Update Troco.java. Fixed #16

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -41,7 +41,7 @@ class Troco {
         while (valor % 2 != 0) {
             count++;
         }
-        papeisMoeda[1] = new PapelMoeda(2, count);
+        papeisMoeda[0] = new PapelMoeda(2, count);
     }
 
     public Iterator<PapelMoeda> getIterator() {


### PR DESCRIPTION
Na linha 44 o indice de papeisMoeda da posição 1 foi escrito duas vezes. Assim conforme a organização do código um dos  indices  foi corrigido para indice 0.