### PR TITLE
Update Troco.java Fixed #20

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -69,7 +69,7 @@ class Troco {
         @Override
         public PapelMoeda next() {
             PapelMoeda ret = null;
-            for (int i = 6; i >= 0 && ret == null; i++) {
+            for (int i = 0; i >= 0 && ret == null; i++) {
                 if (troco.papeisMoeda[i] != null) {
                     ret = troco.papeisMoeda[i];
                     troco.papeisMoeda[i] = null;


### PR DESCRIPTION
Linha 72 - A variável foi inicializada errada, pois iniciou com i=6 que é o limite, corrigida para i=0.